### PR TITLE
Autenticação por LDAP para apenas eleitores listados

### DIFF
--- a/helios/templates/voters_list.html
+++ b/helios/templates/voters_list.html
@@ -33,14 +33,15 @@
                 <input type="radio" name="eligibility" value="openreg" {% if election.openreg and not election.eligibility %}CHECKED{% endif %} /> {% trans "anyone can vote" %}
             </div>
             <div class="form-group">
-                <input type="radio" name="eligibility" value="closedreg" {% if not election.openreg %}CHECKED{% endif %} /> {% trans "only voters listed explicitly below can vote" %}
+                <input type="radio" name="eligibility" value="closedreg" {% if not election.openreg and not election.eligibility %}CHECKED{% endif %} /> {% trans "only voters listed explicitly below can vote" %}
 				<i title="{% trans "Do not forget to upload voters file, using the bulk upload voters button bellow." %}" class="glyphicon glyphicon-info-sign"></i>
             </div>
-            {% if user.user_type in settings.AUTH_LDAP_BIND_AS_AUTHENTICATING_USER %}
+            {% if user.user_type in settings.AUTH_BIND_USERID_TO_VOTERID %}
             <div class="form-group">
                 <input type="radio" name="eligibility" value="privatereg" {% if not election.openreg and election.eligibility %}CHECKED{% endif %} /> {% trans "only voters from the same system" %}
 				<i title="{% trans "Do not forget to upload voters file, using the bulk upload voters button bellow." %}" class="glyphicon glyphicon-info-sign"></i>
             </div>
+            {% endif %}
             {% if categories %}
             <div class="form-group">
                 <input type="radio" name="eligibility" value="{% trans "limitedreg" %}" {% if election.eligibility %}CHECKED{% endif %} /> {% trans "only voters who are members of " %}

--- a/helios/templates/voters_list.html
+++ b/helios/templates/voters_list.html
@@ -33,7 +33,13 @@
                 <input type="radio" name="eligibility" value="openreg" {% if election.openreg and not election.eligibility %}CHECKED{% endif %} /> {% trans "anyone can vote" %}
             </div>
             <div class="form-group">
-                <input type="radio" name="eligibility" value="closedreg" {% if not election.openreg %}CHECKED{% endif %} /> {% trans "only voters listed explicitly below can vote" %} <i title="{% trans "Do not forget to upload voters file, using the bulk upload voters button bellow." %}" class="glyphicon glyphicon-info-sign"></i>
+                <input type="radio" name="eligibility" value="closedreg" {% if not election.openreg %}CHECKED{% endif %} /> {% trans "only voters listed explicitly below can vote" %}
+				<i title="{% trans "Do not forget to upload voters file, using the bulk upload voters button bellow." %}" class="glyphicon glyphicon-info-sign"></i>
+            </div>
+            {% if user.user_type in settings.AUTH_LDAP_BIND_AS_AUTHENTICATING_USER %}
+            <div class="form-group">
+                <input type="radio" name="eligibility" value="privatereg" {% if not election.openreg and election.eligibility %}CHECKED{% endif %} /> {% trans "only voters from the same system" %}
+				<i title="{% trans "Do not forget to upload voters file, using the bulk upload voters button bellow." %}" class="glyphicon glyphicon-info-sign"></i>
             </div>
             {% if categories %}
             <div class="form-group">

--- a/helios/views.py
+++ b/helios/views.py
@@ -1314,7 +1314,7 @@ def voters_eligibility(request, election):
   if eligibility in ['openreg', 'limitedreg']:
     election.openreg= True
 
-  if eligibility == 'closedreg':
+  if eligibility in ['closedreg', 'privatereg']:
     election.openreg= False
 
   if eligibility == 'limitedreg':
@@ -1324,6 +1324,8 @@ def voters_eligibility(request, election):
 
     constraint = AUTH_SYSTEMS[user.user_type].generate_constraint(category_id, user)
     election.eligibility = [{'auth_system': user.user_type, 'constraint': [constraint]}]
+  elif eligibility == 'privatereg':
+    election.eligibility = [{'auth_system': user.user_type}]
   else:
     election.eligibility = None
 

--- a/helios_auth/auth_systems/ldapauth.py
+++ b/helios_auth/auth_systems/ldapauth.py
@@ -70,7 +70,8 @@ def ldap_login_view(request):
                 
                 if user:
                     request.session['ldap_user']  = {
-                        'user_id': user.email,
+                        'username': user.username,
+                        'email': user.email,
                         'name': user.first_name + ' ' + user.last_name,
                     }
                     return HttpResponseRedirect(reverse(after))
@@ -87,9 +88,9 @@ def ldap_login_view(request):
 def get_user_info_after_auth(request):
     return {
        'type': 'ldap',
-       'user_id' : request.session['ldap_user']['user_id'],
+       'user_id' : request.session['ldap_user']['username'],
        'name': request.session['ldap_user']['name'],
-       'info': {'email': request.session['ldap_user']['user_id']},
+       'info': {'email': request.session['ldap_user']['email']},
        'token': None
     }
 

--- a/settings.py
+++ b/settings.py
@@ -340,6 +340,8 @@ AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = True
 
 AUTH_LDAP_ALWAYS_UPDATE_USER = False
 
+AUTH_BIND_USERID_TO_VOTERID = ['ldap']
+
 # Shibboleth auth settings
 SHIBBOLETH_ATTRIBUTE_MAP = { 
     #"Shibboleth-givenName": (True, "first_name"),


### PR DESCRIPTION
@shirlei em algumas eleições acabamos precisando da habilidade de selecionar os eleitores mantendo a autenticação por LDAP. Tenho interesse em ouvir sua opinião sobre as mudanças aqui feitas e estou aberto a discussões e modificações...