### PR TITLE
EncryptedVote JSON should not contain whitespace

### DIFF
--- a/helios/crypto/electionalgs.py
+++ b/helios/crypto/electionalgs.py
@@ -340,7 +340,7 @@ class EncryptedVote(HeliosObject):
     return True
 
   def get_hash(self):
-    return utils.hash_b64(utils.to_json(self.toJSONDict()))
+    return utils.hash_b64(utils.to_json(self.toJSONDict(), no_whitespace=True))
 
   def toJSONDict(self, with_randomness=False):
     return {

--- a/helios/crypto/utils.py
+++ b/helios/crypto/utils.py
@@ -15,8 +15,11 @@ def hash_b64(s):
   result= base64.b64encode(hasher.digest())[:-1]
   return result
 
-def to_json(d):
-  return json.dumps(d, sort_keys=True)
+def to_json(d, no_whitespace=False):
+  if no_whitespace:
+    return json.dumps(d, sort_keys=True, separators=(',',':'))
+  else:
+    return json.dumps(d, sort_keys=True)
 
 def from_json(json_str):
   if not json_str: return None


### PR DESCRIPTION
Sorry for not sharing this earlier. We had this patched in UFSCar's Helios instance since Oct 17 2018.

@shirlei, I'm sending this PR to your repo since I didn't test it against @benadida's upstream, although it is apparently also affected.

Server and client currently generate JSON from EncryptedVote in different formats. [The client](https://github.com/shirlei/helios-server/blob/37ccbdcb64ba2e61b569b30c9fc90d817d523c42/heliosbooth/js/jscrypto/helios.js#L476) generates JSON with no whitespace (e.g. `{"key":"value"}`):

![image](https://user-images.githubusercontent.com/262047/88606094-2717fa80-d052-11ea-85f5-ebeb0c6ff93a.png)

whereas [the server](https://github.com/shirlei/helios-server/blob/37ccbdcb64ba2e61b569b30c9fc90d817d523c42/helios/crypto/electionalgs.py#L342-L343) generates JSON containing whitespace after every `,` and `:` (e.g. `{"key": "value"}`).

Since the EncryptedVote hash is [computed server-side](https://github.com/shirlei/helios-server/blob/37ccbdcb64ba2e61b569b30c9fc90d817d523c42/helios/views.py#L534) when storing a ballot as an AuditedBallot, the resulting hash is different from the one originally displayed to the client.

For example, in unpatched Helios the hash displayed at https://youtu.be/vmce3PrwxkE?t=56 would be different from the hash displayed at https://youtu.be/vmce3PrwxkE?t=285 (the video was recorded with this patch applied, this is why the hash matches).